### PR TITLE
Simpler Travis before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,4 @@ php:
   - 5.3
   - 5.4
 
-before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install
+before_script: composer install


### PR DESCRIPTION
Composer is installed globally on php env for Travis.
So we don't need to download it manually. :smiley: 
