### PR TITLE
Adds phpunit.xml to .gitignore so my local override isn't tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 data/public-suffix-list.txt
+phpunit.xml


### PR DESCRIPTION
I create my own phpunit.xml and add code coverage.  Without phpunit.xml in .gitignore, the new file shows up as untracked and my branch shows up as dirty.  This is a nice clean up.
