### PR TITLE
Add method to create Url objects from $_SERVER

### DIFF
--- a/src/Purl/Url.php
+++ b/src/Purl/Url.php
@@ -116,6 +116,46 @@ class Url extends AbstractPart
     }
 
     /**
+     * Creates an Url instance based on data available on $_SERVER variable.
+     *
+     * @return Url
+     */
+    public static function fromCurrent()
+    {
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') ? 'https' : 'http';
+
+        $host = $_SERVER['HTTP_HOST'];
+        $baseUrl = "$scheme://$host";
+
+        $url = new self($baseUrl);
+
+        if (!empty($_SERVER['REQUEST_URI'])) {
+            list($path, $query) = explode('?', $_SERVER['REQUEST_URI'], 2);
+            $url->set('path', $path);
+            $url->set('query', $query);
+        }
+
+        // Only set port if different from default (80 or 443)
+        if (!empty($_SERVER['SERVER_PORT'])) {
+            $port = $_SERVER['SERVER_PORT'];
+            if (($scheme == 'http' && $port != 80) ||
+                ($scheme == 'https' && $port != 443)) {
+                $url->set('port', $port);
+            }
+        }
+
+        // Authentication
+        if (!empty($_SERVER['PHP_AUTH_USER'])) {
+            $url->set('user', $_SERVER['PHP_AUTH_USER']);
+            if (!empty($_SERVER['PHP_AUTH_PW'])) {
+                $url->set('pass', $_SERVER['PHP_AUTH_PW']);
+            }
+        }
+
+        return $url;
+    }
+
+    /**
      * Gets the ParserInterface instance used to parse this Url instance.
      *
      * @return ParserInterface

--- a/tests/Purl/Test/UrlTest.php
+++ b/tests/Purl/Test/UrlTest.php
@@ -259,6 +259,49 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $url->setFragment(new Fragment(new Path('about'), new Query('param=value')));
         $this->assertEquals('http://jwage.com/about?param=value#about?param=value', (string) $url);
     }
+
+    public function testFromCurrentServerVariables() {
+        $_SERVER['HTTP_HOST'] = 'jwage.com';
+        $_SERVER['SERVER_PORT'] = 80;
+        $_SERVER['REQUEST_URI'] = '/about?param=value';
+
+        $url = Url::fromCurrent();
+        $this->assertEquals('http://jwage.com/about?param=value', (string) $url);
+
+        $_SERVER['HTTPS'] = 'off';
+        $_SERVER['HTTP_HOST'] = 'jwage.com';
+        unset($_SERVER['SERVER_PORT']);
+        unset($_SERVER['REQUEST_URI']);
+
+        $url = Url::fromCurrent();
+        $this->assertEquals('http://jwage.com/', (string) $url);
+
+        $_SERVER['HTTPS'] = 'on';
+        $_SERVER['HTTP_HOST'] = 'jwage.com';
+        $_SERVER['SERVER_PORT'] = 443;
+        unset($_SERVER['REQUEST_URI']);
+
+        $url = Url::fromCurrent();
+        $this->assertEquals('https://jwage.com/', (string) $url);
+
+        unset($_SERVER['HTTPS']);
+        $_SERVER['HTTP_HOST'] = 'jwage.com';
+        $_SERVER['SERVER_PORT'] = 8080;
+        unset($_SERVER['REQUEST_URI']);
+
+        $url = Url::fromCurrent();
+        $this->assertEquals('http://jwage.com:8080/', (string) $url);
+
+        unset($_SERVER['HTTPS']);
+        $_SERVER['HTTP_HOST'] = 'jwage.com';
+        $_SERVER['SERVER_PORT'] = 80;
+        unset($_SERVER['REQUEST_URI']);
+        $_SERVER['PHP_AUTH_USER'] = 'user';
+        $_SERVER['PHP_AUTH_PW'] = 'passwd123';
+
+        $url = Url::fromCurrent();
+        $this->assertEquals('http://user:passwd123@jwage.com/', (string) $url);
+    }
 }
 
 class TestParser implements ParserInterface


### PR DESCRIPTION
Adds a method `\Purl\Url::fromCurrent()` to build an URL using data available on $_SERVER variable.

This is a very basic code - probably doesn't work in all cases, but I wanted some feedback on it. Tested on nginx + php-fpm.

**Edit:**
This refers to #15 