### PR TITLE
Updates PHP Domain Parser to v2 (IDNA support), adds tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     },
     "require": {
     	"php": ">=5.3.0",
-        "jeremykendall/php-domain-parser": "1.3.1"
+        "jeremykendall/php-domain-parser": "~2.0"
     }
 }

--- a/tests/Purl/Test/PublicSuffixListTest.php
+++ b/tests/Purl/Test/PublicSuffixListTest.php
@@ -49,6 +49,11 @@ class PublicSuffixListTest extends PHPUnit_Framework_TestCase
             array('test.museum', 'museum', 'test.museum', null, 'test.museum'),
             array('bob.smith.name', 'name', 'smith.name', 'bob', 'bob.smith.name'),
             array('tons.of.info', 'info', 'of.info', 'tons', 'tons.of.info'),
+            array('http://Яндекс.РФ', 'рф', 'яндекс.рф', null, 'яндекс.рф'),
+            array('www.食狮.中国', '中国', '食狮.中国', 'www', 'www.食狮.中国'),
+            array('食狮.com.cn', 'com.cn', '食狮.com.cn', null, '食狮.com.cn'),
+            array('www.xn--85x722f.xn--fiqs8s', 'xn--fiqs8s', 'xn--85x722f.xn--fiqs8s', 'www', 'www.xn--85x722f.xn--fiqs8s'),
+            array('xn--85x722f.com.cn', 'com.cn', 'xn--85x722f.com.cn', null, 'xn--85x722f.com.cn'),
         );
     }
 }


### PR DESCRIPTION
Important: This is a BC breaking change, as PHP Domain Parser 2.0.0 requires `ext-intl` and `ext-mbstring`.