### PR TITLE
Fix PHP notice message when calling method Purl\Url::fromCurrent() without query string in the URL

### DIFF
--- a/src/Purl/Url.php
+++ b/src/Purl/Url.php
@@ -130,10 +130,15 @@ class Url extends AbstractPart
         $url = new self($baseUrl);
 
         if (!empty($_SERVER['REQUEST_URI'])) {
-            $parts = explode('?', $_SERVER['REQUEST_URI'], 2);
-            $url->set('path', $parts[0]);
-            if (count($parts) > 1)
-                $url->set('query', $parts[1]);
+            if (strpos($_SERVER['REQUEST_URI'], '?') !== false) {
+                list($path, $query) = explode('?', $_SERVER['REQUEST_URI'], 2);
+            } else {
+                $path = $_SERVER['REQUEST_URI'];
+                $query = '';
+            }
+
+            $url->set('path', $path);
+            $url->set('query', $query);
         }
 
         // Only set port if different from default (80 or 443)

--- a/tests/Purl/Test/UrlTest.php
+++ b/tests/Purl/Test/UrlTest.php
@@ -263,6 +263,11 @@ class UrlTest extends PHPUnit_Framework_TestCase
     public function testFromCurrentServerVariables() {
         $_SERVER['HTTP_HOST'] = 'jwage.com';
         $_SERVER['SERVER_PORT'] = 80;
+        $_SERVER['REQUEST_URI'] = '/about';
+
+        $url = Url::fromCurrent();
+        $this->assertEquals('http://jwage.com/about', (string) $url);
+
         $_SERVER['REQUEST_URI'] = '/about?param=value';
 
         $url = Url::fromCurrent();


### PR DESCRIPTION
The new method Purl\Url::fromCurrent() triggers PHP notice messages when parsing URLs that don't have query strings. This fix resolves the issue.