### PR TITLE
Fix seg fault in Query::doInitialize()

### DIFF
--- a/src/Purl/Query.php
+++ b/src/Purl/Query.php
@@ -68,8 +68,8 @@ class Query extends AbstractPart
      */
     protected function doInitialize()
     {
-        parse_str($this->query);
+        parse_str($this->query, $data);
 
-        $this->data = get_defined_vars();
+        $this->data = $data;
     }
 }


### PR DESCRIPTION
parse_str(), without a second argument, can cause php segfaults, as shown here: https://bugs.php.net/bug.php?id=73181

This change avoids the segfault (because with a second argument, we avoid modifying the current scope), and also makes the code a bit cleaner.