### PR TITLE
__set() must return void as of PHP 8.0

### DIFF
--- a/src/Purl/AbstractPart.php
+++ b/src/Purl/AbstractPart.php
@@ -111,9 +111,9 @@ abstract class AbstractPart implements ArrayAccess
     /**
      * @param mixed $value
      */
-    public function __set(string $key, $value) : AbstractPart
+    public function __set(string $key, $value) : void
     {
-        return $this->set($key, $value);
+        $this->set($key, $value);
     }
 
     public function __unset(string $key) : void


### PR DESCRIPTION
This will break fluent interfaces when magic __set() is involved / dynamic property setting is used.

Reported in https://github.com/jwage/purl/issues/81